### PR TITLE
Add tvOS support 📺

### DIFF
--- a/GoSquared.podspec
+++ b/GoSquared.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.author           = { "Giles Williams" => "giles.williams@gmail.com",
                          "Ed Wellbrook"   => "edwellbrook@gmail.com" }
 
-  s.platform         = :ios, "6.0"
+  s.ios.deployment_target = '6.0'
+  s.tvos.deployment_target = '9.0'
   s.requires_arc     = true
   s.source           = { :git => "https://github.com/gosquared/gosquared-ios.git", :tag => "v#{s.version}" }
   s.default_subspec  = "GoSquared"

--- a/GoSquared/GSDevice.m
+++ b/GoSquared/GSDevice.m
@@ -21,13 +21,13 @@ static GSDevice *currentGSDevice = nil;
     if (currentGSDevice == nil) {
         currentGSDevice = [[GSDevice alloc] init];
     }
-
+    
     return currentGSDevice;
 }
 
 - (GSDevice *)init {
     self = [super init];
-
+    
     if (self) {
         // screen
         CGRect screenRect = [[UIScreen mainScreen] bounds];
@@ -35,53 +35,58 @@ static GSDevice *currentGSDevice = nil;
         self.screenWidth = [NSNumber numberWithFloat:screenRect.size.width];
         self.screenPixelRatio = [NSNumber numberWithFloat:[UIScreen mainScreen].scale];
         self.colorDepth = @24;
-
+        
         // device ID
         self.udid = [self deviceIdentifier];
-
+        
         // timezone
         NSDate *date = [NSDate new];
         NSTimeZone *currentTimeZone = [NSTimeZone localTimeZone];
         NSTimeZone *utcTimeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
-
+        
         NSInteger currentGMTOffset = [currentTimeZone secondsFromGMTForDate:date];
         NSInteger gmtOffset = [utcTimeZone secondsFromGMTForDate:date];
         NSTimeInterval gmtInterval = currentGMTOffset - gmtOffset;
         self.timezoneOffset = [NSNumber numberWithLongLong:(gmtInterval / 60)*-1];
-
+        
         NSLocale *l = [NSLocale currentLocale];
-
+        
         // language
         self.isoLanguage = [[[l objectForKey:NSLocaleIdentifier] lowercaseString] stringByReplacingOccurrencesOfString:@"_" withString:@"-"];
-
+        
         // user agent
         NSArray *versionComponents = [[UIDevice currentDevice].systemVersion componentsSeparatedByString:@"."];
-
+        
         NSBundle *bundle = [NSBundle mainBundle];
         NSDictionary *info = [bundle infoDictionary];
-
+        
         NSString *appNameStr = [info objectForKey:@"CFBundleName"];
         NSString *appVersionStr = [info objectForKey:@"CFBundleShortVersionString"];
-
+        
         NSString *iOSVersionStr = [versionComponents componentsJoinedByString:@"_"];
-        NSString *deviceType = [[UIDevice currentDevice].model componentsSeparatedByString:@" "][0];
-
+        
+        #if TARGET_OS_TV
+            NSString *deviceType = @"Apple TV";
+        #else
+            NSString *deviceType = [[UIDevice currentDevice].model componentsSeparatedByString:@" "][0];
+        #endif
+        
         self.userAgent = [NSString stringWithFormat:@"%@/%@ (%@; CPU OS %@ like Mac OS X)", appNameStr, appVersionStr, deviceType, iOSVersionStr];
     }
-
+    
     return self;
 }
 
 - (NSString *)deviceIdentifier {
     NSString *deviceIdentifier = [[NSUserDefaults standardUserDefaults] objectForKey:kGSUDIDDefaultsKey];
-
+    
     if (deviceIdentifier == nil) {
         deviceIdentifier = [self createUUID];
-
+        
         [[NSUserDefaults standardUserDefaults] setObject:deviceIdentifier forKey:kGSUDIDDefaultsKey];
         [[NSUserDefaults standardUserDefaults] synchronize];
     }
-
+    
     return deviceIdentifier;
 }
 

--- a/GoSquared/GSPageviewTracker.m
+++ b/GoSquared/GSPageviewTracker.m
@@ -139,7 +139,7 @@ static NSString * const kGSPageviewLastTimestamp = @"com.gosquared.pageview.last
 
     NSString *os = @"iOS";
     
-    #ifdef TARGET_OS_TV
+    #if TARGET_OS_TV
         os = @"tvOS";
     #endif
     

--- a/GoSquared/GSPageviewTracker.m
+++ b/GoSquared/GSPageviewTracker.m
@@ -104,7 +104,7 @@ static NSString * const kGSPageviewLastTimestamp = @"com.gosquared.pageview.last
     self.urlString = urlString;
 
     if (self.title == nil) {
-        self.title = @"";
+        self.title = @"Unknown";
     }
 
     self.valid = YES;
@@ -137,9 +137,15 @@ static NSString * const kGSPageviewLastTimestamp = @"com.gosquared.pageview.last
 - (NSDictionary *)generateBodyForPing:(BOOL)isForPing {
     GSDevice *device = [GSDevice currentDevice];
 
+    NSString *os = @"iOS";
+    
+    #ifdef TARGET_OS_TV
+        os = @"tvOS";
+    #endif
+    
     NSMutableDictionary *page = [NSMutableDictionary dictionaryWithDictionary:@{
                                                                                 @"url": self.urlString,
-                                                                                @"title": [NSString stringWithFormat:@"iOS: %@", self.title]
+                                                                                @"title": [NSString stringWithFormat:@"%@: %@", os, self.title]
                                                                                 }];
 
     if (isForPing) {

--- a/GoSquared/GSTracker.m
+++ b/GoSquared/GSTracker.m
@@ -84,8 +84,10 @@ static NSString * const kGSTransactionLastTimestamp = @"com.gosquared.transactio
 - (void)trackScreen:(NSString *)title withPath:(NSString *)path {
     [self verifyCredsAreSet];
 
-    if (path == nil) {
+    if (path == nil && title != nil) {
         path = [title stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    } else if (path == nil && title == nil) {
+        path = @"/";
     }
 
     NSString *bundleId = [[NSBundle mainBundle] bundleIdentifier];


### PR DESCRIPTION
- Added tvOS as a deployment target to the podspec
- Added check for OS that gets sent to GoSquared so tvOS or iOS shows on the dashboard
- Added "Unknown" when a view controller dos not have its title set.

This fixes #5. Version hasn't yet been bumped to 0.0.8. 